### PR TITLE
Add <stpt> as valid subtarget

### DIFF
--- a/model.lua
+++ b/model.lua
@@ -61,7 +61,7 @@ function model:updatePlayers()
 	local party = T(windower.ffxi.get_party())
 	local zone = windower.ffxi.get_info().zone
 	local target = windower.ffxi.get_mob_by_target('t')
-	local subtarget = windower.ffxi.get_mob_by_target('st') or windower.ffxi.get_mob_by_target('stpt')
+	local subtarget = windower.ffxi.get_mob_by_target('st') or windower.ffxi.get_mob_by_target('stpt') or windower.ffxi.get_mob_by_target('stal')
 	
 	for i = 0, 5 do
 		local member = party['p%i':format(i % 6)]

--- a/model.lua
+++ b/model.lua
@@ -61,7 +61,7 @@ function model:updatePlayers()
 	local party = T(windower.ffxi.get_party())
 	local zone = windower.ffxi.get_info().zone
 	local target = windower.ffxi.get_mob_by_target('t')
-	local subtarget = windower.ffxi.get_mob_by_target('st')
+	local subtarget = windower.ffxi.get_mob_by_target('st') or windower.ffxi.get_mob_by_target('stpt')
 	
 	for i = 0, 5 do
 		local member = party['p%i':format(i % 6)]


### PR DESCRIPTION
Arcon recently pushed \<stpt> as valid target to Windower 4 live.
Being a subtarget after all, this is a quick and dirty way to include this behavior in XivParty.
Tested working on retail.